### PR TITLE
Make rotation work in simulation

### DIFF
--- a/simgui-ds.json
+++ b/simgui-ds.json
@@ -1,4 +1,9 @@
 {
+  "Keyboard 0 Settings": {
+    "window": {
+      "visible": true
+    }
+  },
   "keyboardJoysticks": [
     {
       "axisConfig": [
@@ -15,9 +20,14 @@
           "decayRate": 0.0,
           "incKey": 82,
           "keyRate": 0.009999999776482582
+        },
+        {},
+        {
+          "decKey": 45,
+          "incKey": 61
         }
       ],
-      "axisCount": 3,
+      "axisCount": 6,
       "buttonCount": 4,
       "buttonKeys": [
         90,


### PR DESCRIPTION
Added rotation to simulation by adding up to axis 5 in `Keyboard0` and adding keybinds to axis 4 (Right Joystick X)
Keys: `-` to rotate left, `+` to rotate right